### PR TITLE
support $set and $set_once properties

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,6 +14,8 @@ export type PostHogComponent = {
         userId: string;
         event: string;
         properties?: Record<string, unknown>;
+        setProperties?: Record<string, unknown>;
+        setOnceProperties?: Record<string, unknown>;
       },
       null
     >;
@@ -38,7 +40,9 @@ export type PostHogOptions = {
  * await posthog.trackUserEvent(ctx, {
  *   userId: "user_123",
  *   event: "user_created",
- *   properties: { email: "user@example.com" }
+ *   properties: { email: "user@example.com" },
+ *   setProperties: { name: "John Doe" },
+ *   setOnceProperties: { first_login: Date.now() }
  * });
  * ```
  */
@@ -61,6 +65,8 @@ export class PostHog {
       userId: string;
       event: string;
       properties?: Record<string, unknown>;
+      setProperties?: Record<string, unknown>;
+      setOnceProperties?: Record<string, unknown>;
     }
   ): Promise<void> {
     if (!this.apiKey) {
@@ -74,6 +80,8 @@ export class PostHog {
       userId: data.userId,
       event: data.event,
       properties: data.properties,
+      setProperties: data.setProperties,
+      setOnceProperties: data.setOnceProperties,
     });
   }
 }

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -12,6 +12,8 @@ export const trackEvent = action({
     userId: v.string(),
     event: v.string(),
     properties: v.optional(v.any()),
+    setProperties: v.optional(v.any()),
+    setOnceProperties: v.optional(v.any()),
   },
   returns: v.null(),
   handler: async (_ctx, args) => {
@@ -37,6 +39,8 @@ export const trackEvent = action({
         distinct_id: args.userId,
         properties: {
           ...args.properties,
+          ...(args.setProperties && { $set: args.setProperties }),
+          ...(args.setOnceProperties && { $set_once: args.setOnceProperties }),
           $lib: "convex-posthog",
           $lib_version: "0.1.1",
         },


### PR DESCRIPTION
Convex does not allow passing $ prefixed args, so custom properties seem like the best way to pass person properties on to Posthog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event tracking now supports optional "set" and "set once" properties that are merged into tracked event payloads when provided, allowing callers to update or initialize user/event properties alongside standard event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->